### PR TITLE
Create bin/ and man1/ directories before install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ OBJECTS = \
     clean-coverage report-coverage \
     universal-dedup universal-dist \
 	compiledb tidy \
-    list
+    list mkdirs
 
 all: dedup
 
@@ -118,11 +118,11 @@ report-coverage:
 
 PREFIX ?= /usr/local
 
-install: dedup
+install: dedup mkdirs
 	install dedup $(PREFIX)/bin
 	install dedup.1 $(PREFIX)/share/man/man1
 
-build/dist:
+build/dist mkdirs:
 	mkdir -p $(PREFIX)/bin
 	mkdir -p $(PREFIX)/share/man/man1
 


### PR DESCRIPTION
Before this patch, trying to `make install` lead to an error, as seen below:

    $ make PREFIX="$PWD" install
    install dedup /Users/gurjeet/dev/DEDUP/bin
    install dedup.1 /Users/gurjeet/dev/DEDUP/share/man/man1
    install: cannot create regular file '/Users/gurjeet/dev/DEDUP/share/man/man1': No such file or directory
    make: *** [install] Error 1