### PR TITLE
Update README.md to include block corruption risk caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ A macOS utility to replace duplicate file data with a copy-on-write clone.
 
 **dedup** `[-PVnvx]` [`-t`&nbsp;**threads**] [`-d`&nbsp;**depth**] [*file&nbsp;...*]
 
+# WARNING: Block Corruption Risk
+
+APFS cloning deduplicates storage by making all instances of a file reference the same underlying block.
+**If that block becomes corrupted, all cloned instances are affected.**
+This is generally fine for software projects where files can be regenerated or checked out again, 
+but it poses a risk for unique or irreplaceable files.
+
+To mitigate this, ensure you maintain separate backups on different hardware. 
+Cloning **should not** be considered a substitute for a proper backup strategy.
+
 # DESCRIPTION
 
 **dedup** finds files with identical content using the provided *file* arguments.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,6 @@ A macOS utility to replace duplicate file data with a copy-on-write clone.
 
 **dedup** `[-PVnvx]` [`-t`&nbsp;**threads**] [`-d`&nbsp;**depth**] [*file&nbsp;...*]
 
-# WARNING: Block Corruption Risk
-
-APFS cloning deduplicates storage by making all instances of a file reference the same underlying block.
-**If that block becomes corrupted, all cloned instances are affected.**
-This is generally fine for software projects where files can be regenerated or checked out again, 
-but it poses a risk for unique or irreplaceable files.
-
-To mitigate this, ensure you maintain separate backups on different hardware. 
-Cloning **should not** be considered a substitute for a proper backup strategy.
-
 # DESCRIPTION
 
 **dedup** finds files with identical content using the provided *file* arguments.
@@ -197,6 +187,19 @@ may be changed and then overwritten by a clone with it's previous content.
 
 It may be reasonable for future versions to include additional checks and locks
 to ensure modifications are detected prior to clone replacement.
+
+## Block Corruption Risk
+
+APFS cloning deduplicates storage by making all instances of a file reference the
+same underlying blocks. **If even one of those blocks becomes corrupted, all
+cloned instances are affected.** This is not a problem with
+**dedup**
+or something that
+**dedup**
+can prevent, but is a fact of any filesystem. Reducing the number of copies in a
+single volume reduces one level of redundancy. This may pose a risk for unique or
+irreplaceable files. It is always a good idea to maintain backups on different
+logical volumes of any files, including ones that may be deduplicated.
 
 # HISTORY
 


### PR DESCRIPTION
From [your comment on the Hyperspace thread](https://news.ycombinator.com/item?id=43179652):

> There is one huge caveat I should add to the README - block corruption happens. Having a second copy of a file is a crude form of backup. Cloning causes all instances to use the same block, so if that one instance is corrupted, all clones are. That’s fine for software projects with generated files that can be rebuilt or checked out again, but introduces some risk for files that may not otherwise be replaceable. I keep multiple backups of all that stuff in hardware other than where I’m deduping, so I dedup with abandon.

I asked ChatGPT to rewrite it as a warning. I read it and it seems ok to me. Feel free to make whatever changes you'd like, of course. Sorry for not naming the branch something else.